### PR TITLE
Add topic selector and unit tests

### DIFF
--- a/tests/test_topic_selector.py
+++ b/tests/test_topic_selector.py
@@ -1,0 +1,13 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pytest
+from topic_selector import get_response
+
+@pytest.mark.parametrize("path,expected", [
+    ('/sports', 'You selected sports.'),
+    ('/music', 'You selected music.'),
+    ('/science', 'You selected science.'),
+    ('/unknown', 'Unknown topic.'),
+])
+def test_get_response(path, expected):
+    assert get_response(path) == expected

--- a/topic_selector.py
+++ b/topic_selector.py
@@ -1,0 +1,10 @@
+TOPIC_RESPONSES = {
+    '/sports': 'You selected sports.',
+    '/music': 'You selected music.',
+    '/science': 'You selected science.'
+}
+
+
+def get_response(path: str) -> str:
+    """Return the predefined response for a topic path."""
+    return TOPIC_RESPONSES.get(path, 'Unknown topic.')


### PR DESCRIPTION
## Summary
- add a simple `topic_selector` module with predefined responses
- implement pytest unit tests covering response selection for each topic path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b869e018483209a306ee9b9cc084f